### PR TITLE
distutils: Append includedir used for install

### DIFF
--- a/snakeoil/distutils_extensions.py
+++ b/snakeoil/distutils_extensions.py
@@ -187,6 +187,7 @@ class build_ext(dst_build_ext.build_ext):
         dst_build_ext.build_ext.initialize_options(self)
         self.build_optional = None
         self.disable_distutils_flag_fixing = False
+        self.default_header_install_dir = None
 
     def finalize_options(self):
         dst_build_ext.build_ext.finalize_options(self)
@@ -194,6 +195,13 @@ class build_ext(dst_build_ext.build_ext):
             self.build_optional = True
         if not self.build_optional:
             self.extensions = [ext for ext in self.extensions if not isinstance(ext, OptionalExtension)] or None
+        self.set_undefined_options('install', ('install_headers', 'default_header_install_dir'))
+        if self.default_header_install_dir:
+            self.default_header_install_dir = os.path.dirname(self.default_header_install_dir)
+            for e in self.extensions:
+                # include_dirs may actually be shared between multiple extensions
+                if self.default_header_install_dir not in e.include_dirs:
+                    e.include_dirs.append(self.default_header_install_dir)
 
     def build_extensions(self):
         if self.debug:


### PR DESCRIPTION
Append includedir specified for the install command when building extensions. This fixes building reverse dependencies in virtualenv, when the default include path does not include the include directory used by virtualenv-installed packages.