### PR TITLE
ensure_dirs() cleanup

### DIFF
--- a/snakeoil/osutils/__init__.py
+++ b/snakeoil/osutils/__init__.py
@@ -120,7 +120,7 @@ def ensure_dirs(path, gid=-1, uid=-1, mode=0o777, minimal=True):
 
                     # if it's a subdir, we need +wx at least
                     if apath != base:
-                        sticky_parent = (st.st_gid & stat.S_ISGID)
+                        sticky_parent = (st.st_mode & stat.S_ISGID)
 
                 except OSError:
                     # nothing exists.

--- a/snakeoil/osutils/__init__.py
+++ b/snakeoil/osutils/__init__.py
@@ -120,12 +120,6 @@ def ensure_dirs(path, gid=-1, uid=-1, mode=0o777, minimal=True):
 
                     # if it's a subdir, we need +wx at least
                     if apath != base:
-                        if (st.st_mode & 0o300) != 0o300:
-                            try:
-                                os.chmod(base, (st.st_mode | 0o300))
-                            except OSError:
-                                return False
-                            resets.append((base, st.st_mode))
                         sticky_parent = (st.st_gid & stat.S_ISGID)
 
                 except OSError:

--- a/snakeoil/osutils/__init__.py
+++ b/snakeoil/osutils/__init__.py
@@ -142,8 +142,8 @@ def ensure_dirs(path, gid=-1, uid=-1, mode=0o777, minimal=True):
             try:
                 for base, m in reversed(resets):
                     os.chmod(base, m)
-                if uid != -1 or gid != -1:
-                    os.chown(base, uid, gid)
+                    if gid != -1 or uid != -1:
+                        os.chown(base, uid, gid)
             except OSError:
                 return False
 


### PR DESCRIPTION
Far from a perfect solution but fixes at least some of the issues in #14. Long story short, removes the logic for altering permission on existing dirs, and fixes the 'weird' chown() to be more useful. Still not sure if that was the original intent though.