### PR TITLE
Fix locking code based on tests on Solaris

### DIFF
--- a/snakeoil/osutils/__init__.py
+++ b/snakeoil/osutils/__init__.py
@@ -290,7 +290,7 @@ class FsLock(object):
                 raise NonExistent(path)
 
     def _acquire_fd(self):
-        flags = os.R_OK
+        flags = os.O_RDONLY
         if self.create:
             flags |= os.O_CREAT
         try:

--- a/snakeoil/osutils/__init__.py
+++ b/snakeoil/osutils/__init__.py
@@ -290,7 +290,9 @@ class FsLock(object):
                 raise NonExistent(path)
 
     def _acquire_fd(self):
-        flags = os.O_RDONLY
+        # write access is needed to acquire LOCK_EX
+        # https://github.com/pkgcore/snakeoil/pull/23
+        flags = os.O_RDWR
         if self.create:
             flags |= os.O_CREAT
         try:

--- a/snakeoil/osutils/__init__.py
+++ b/snakeoil/osutils/__init__.py
@@ -302,7 +302,10 @@ class FsLock(object):
         if self.fd is None:
             self._acquire_fd()
         # we do it this way, due to the fact try/except is a bit of a hit
-        if not blocking:
+        # note that LOCK_UN can never block, and combining it with
+        # LOCK_NB triggers ValueError on Solaris
+        # https://github.com/pkgcore/snakeoil/pull/23
+        if not blocking and flags != fcntl.LOCK_UN:
             try:
                 fcntl.flock(self.fd, flags|fcntl.LOCK_NB)
             except IOError as ie:

--- a/snakeoil/test/test_osutils.py
+++ b/snakeoil/test/test_osutils.py
@@ -321,7 +321,7 @@ class FsLockTest(TempDirMixin):
         with open(path) as f:
             # acquire and release a read lock
             fcntl.flock(f, fcntl.LOCK_SH | fcntl.LOCK_NB)
-            fcntl.flock(f, fcntl.LOCK_UN | fcntl.LOCK_NB)
+            fcntl.flock(f, fcntl.LOCK_UN)
             # we can't acquire an exclusive lock
             self.assertRaises(
                 IOError, fcntl.flock, f, fcntl.LOCK_EX | fcntl.LOCK_NB)
@@ -330,7 +330,7 @@ class FsLockTest(TempDirMixin):
             fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
             self.assertFalse(lock.acquire_read_lock(False))
             self.assertFalse(lock.acquire_write_lock(False))
-            fcntl.flock(f, fcntl.LOCK_UN | fcntl.LOCK_NB)
+            fcntl.flock(f, fcntl.LOCK_UN)
             # acquire an exclusive/write lock
             self.assertTrue(lock.acquire_write_lock(False))
             self.assertRaises(
@@ -338,18 +338,18 @@ class FsLockTest(TempDirMixin):
             # downgrade to read lock
             self.assertTrue(lock.acquire_read_lock())
             fcntl.flock(f, fcntl.LOCK_SH | fcntl.LOCK_NB)
-            fcntl.flock(f, fcntl.LOCK_UN | fcntl.LOCK_NB)
+            fcntl.flock(f, fcntl.LOCK_UN)
             self.assertRaises(
                 IOError, fcntl.flock, f, fcntl.LOCK_EX | fcntl.LOCK_NB)
             # and release
             lock.release_read_lock()
             fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
-            fcntl.flock(f, fcntl.LOCK_UN | fcntl.LOCK_NB)
+            fcntl.flock(f, fcntl.LOCK_UN)
 
             self.assertTrue(lock.acquire_write_lock(False))
             lock.release_write_lock()
             fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
-            fcntl.flock(f, fcntl.LOCK_UN | fcntl.LOCK_NB)
+            fcntl.flock(f, fcntl.LOCK_UN)
 
 
 class TestAccess(TempDirMixin):

--- a/snakeoil/test/test_osutils.py
+++ b/snakeoil/test/test_osutils.py
@@ -318,7 +318,7 @@ class FsLockTest(TempDirMixin):
         # do this all non-blocking to avoid hanging tests
         self.assertTrue(lock.acquire_read_lock(False))
         # file should exist now
-        with open(path) as f:
+        with open(path, 'r+') as f:
             # acquire and release a read lock
             fcntl.flock(f, fcntl.LOCK_SH | fcntl.LOCK_NB)
             fcntl.flock(f, fcntl.LOCK_UN)

--- a/snakeoil/test/test_osutils.py
+++ b/snakeoil/test/test_osutils.py
@@ -312,8 +312,8 @@ class FsLockTest(TempDirMixin):
         self.assertRaises(osutils.NonExistent, osutils.FsLock,
                           pjoin(self.dir, 'missing'))
 
-    def test_locking(self):
-        path = pjoin(self.dir, 'lockfile')
+    def test_fslock_read_lock(self):
+        path = pjoin(self.dir, 'lockfile-read')
         lock = osutils.FsLock(path, True)
         # do this all non-blocking to avoid hanging tests
         self.assertTrue(lock.acquire_read_lock(False))
@@ -325,29 +325,69 @@ class FsLockTest(TempDirMixin):
             # we can't acquire an exclusive lock
             self.assertRaises(
                 IOError, fcntl.flock, f, fcntl.LOCK_EX | fcntl.LOCK_NB)
-            lock.release_read_lock()
+
+    def test_fslock_release_read_lock(self):
+        path = pjoin(self.dir, 'lockfile-release-read')
+        lock = osutils.FsLock(path, True)
+        # do this all non-blocking to avoid hanging tests
+        self.assertTrue(lock.acquire_read_lock(False))
+        lock.release_read_lock()
+        # file should exist now
+        with open(path, 'r+') as f:
             # but now we can
             fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
-            self.assertFalse(lock.acquire_read_lock(False))
-            self.assertFalse(lock.acquire_write_lock(False))
             fcntl.flock(f, fcntl.LOCK_UN)
-            # acquire an exclusive/write lock
-            self.assertTrue(lock.acquire_write_lock(False))
+
+    def test_fslock_write_lock(self):
+        path = pjoin(self.dir, 'lockfile-write')
+        lock = osutils.FsLock(path, True)
+        # do this all non-blocking to avoid hanging tests
+        # acquire an exclusive/write lock
+        self.assertTrue(lock.acquire_write_lock(False))
+        # file should exist now
+        with open(path, 'r+') as f:
             self.assertRaises(
                 IOError, fcntl.flock, f, fcntl.LOCK_EX | fcntl.LOCK_NB)
-            # downgrade to read lock
-            self.assertTrue(lock.acquire_read_lock())
+
+    def test_fslock_release_write_lock(self):
+        path = pjoin(self.dir, 'lockfile-release-write')
+        lock = osutils.FsLock(path, True)
+        # do this all non-blocking to avoid hanging tests
+        # acquire an exclusive/write lock
+        self.assertTrue(lock.acquire_write_lock(False))
+        lock.release_write_lock()
+        # file should exist now
+        with open(path, 'r+') as f:
+            fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            fcntl.flock(f, fcntl.LOCK_UN)
+
+    def test_fslock_downgrade_lock(self):
+        path = pjoin(self.dir, 'lockfile-downgrade')
+        lock = osutils.FsLock(path, True)
+        # do this all non-blocking to avoid hanging tests
+        # acquire an exclusive/write lock
+        self.assertTrue(lock.acquire_write_lock(False))
+        # downgrade to read lock
+        self.assertTrue(lock.acquire_read_lock())
+        # file should exist now
+        with open(path, 'r+') as f:
             fcntl.flock(f, fcntl.LOCK_SH | fcntl.LOCK_NB)
             fcntl.flock(f, fcntl.LOCK_UN)
             self.assertRaises(
                 IOError, fcntl.flock, f, fcntl.LOCK_EX | fcntl.LOCK_NB)
-            # and release
-            lock.release_read_lock()
-            fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
-            fcntl.flock(f, fcntl.LOCK_UN)
 
-            self.assertTrue(lock.acquire_write_lock(False))
-            lock.release_write_lock()
+    def test_fslock_release_downgraded_lock(self):
+        path = pjoin(self.dir, 'lockfile-release-downgraded')
+        lock = osutils.FsLock(path, True)
+        # do this all non-blocking to avoid hanging tests
+        # acquire an exclusive/write lock
+        self.assertTrue(lock.acquire_write_lock(False))
+        # downgrade to read lock
+        self.assertTrue(lock.acquire_read_lock())
+        # and release
+        lock.release_read_lock()
+        # file should exist now
+        with open(path, 'r+') as f:
             fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
             fcntl.flock(f, fcntl.LOCK_UN)
 


### PR DESCRIPTION
Surprising, isn't it?

So far:
1. `LOCK_UN|LOCK_NB` can't be used on Solaris,
2. `R_OK` is invalid for `os.open()` :-P,
3. and anyway, you need to have the file open for writing in order to acquire exclusive lock.