### PR TITLE
Fix snakeoil.process.is_running() for better portability

### DIFF
--- a/snakeoil/process/__init__.py
+++ b/snakeoil/process/__init__.py
@@ -110,7 +110,7 @@ def get_proc_count(force=False):
 def is_running(pid):
     """Determine if a process is running or not.
 
-    Note that this returns False if process doesn't exist.
+    Note that this raises ProcessNotFound if process doesn't exist.
 
     :param pid: a process ID
     :return: boolean of whether the process is running or not

--- a/snakeoil/process/__init__.py
+++ b/snakeoil/process/__init__.py
@@ -119,6 +119,11 @@ def is_running(pid):
         # see if the process exists
         os.kill(pid, 0)
 
+        # assume process existence is enough when Linux /proc is not
+        # available
+        if os.uname()[0].lower() != 'linux':
+            return True
+
         # get the process status
         with open("/proc/%s/status" % pid, 'r') as f:
             for line in f:

--- a/snakeoil/test/test_process.py
+++ b/snakeoil/test/test_process.py
@@ -62,7 +62,12 @@ class TestIsRunning(TestCase):
         else:
             # wait for signal to propagate
             time.sleep(1)
-            self.assertFalse(process.is_running(pid))
+            # the return value is reliable only on Linux
+            # on other systems, just check if it doesn't ProcessNotFound
+            if os.uname()[0].lower() == 'linux':
+                self.assertFalse(process.is_running(pid))
+            else:
+                process.is_running(pid)
             os.kill(pid, signal.SIGKILL)
 
         with mock.patch('snakeoil.process.os.kill') as kill:


### PR DESCRIPTION
This method relies on /proc/*/status lookup in order to determine process status, with the code working only on Linux. On OSX, it just raises ProcessNotFound due to /proc being unavailable. In Solaris, it fails horribly because /proc/*/status is a binary file.

Instead of failing hard, assuming `True` if the process exists when not on Linux sounds like an acceptable solution. However, I'd honestly rather kill the thing.