### PR TITLE
Support platform (configure) checks in pkgdist, fix Solaris&OSX portability issues

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,15 @@ class config(pkgdist.config):
             return self.check_struct_member('struct dirent', 'd_type',
                     ('dirent.h',))
 
+        @pkgdist.check_define('TIME_T_LONGER_THAN_LONG')
+        @pkgdist.print_check("Checking if sizeof(time_t) > sizeof(long)", 'yes', 'no')
+        def check_TIME_T_LONGER_THAN_LONG(self):
+            # Ye old trick here: the conditional is const, so we can use it
+            # as array size. If it evaluates to false, we return -1 which is
+            # invalid and causes the compilation to fail.
+            return self.try_compile('int x[(sizeof(time_t) > sizeof(long)) ? 1 : -1];',
+                    ('sys/types.h',))
+
 if not pkgdist.is_py3k:
     extensions.extend([
         OptionalExtension(

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,14 @@ extra_kwargs = dict(
 
 extensions = []
 
+class config(pkgdist.config):
+    if not pkgdist.is_py3k:
+        @pkgdist.check_define('HAVE_STAT_TV_NSEC')
+        @pkgdist.print_check("Checking for struct stat.st_mtim.tv_nsec")
+        def check_HAVE_STAT_TV_NSEC(self):
+            return self.check_struct_member('struct stat', 'st_mtim.tv_nsec',
+                    ('sys/types.h', 'sys/stat.h'))
+
 if not pkgdist.is_py3k:
     extensions.extend([
         OptionalExtension(
@@ -62,7 +70,7 @@ setup(
         'sdist': pkgdist.sdist,
         'build_ext': pkgdist.build_ext,
         'build_py': pkgdist.build_py,
-        'config': pkgdist.config,
+        'config': config,
         'test': pkgdist.test,
     },
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,12 @@ class config(pkgdist.config):
             return self.check_struct_member('struct stat', 'st_mtim.tv_nsec',
                     ('sys/types.h', 'sys/stat.h'))
 
+        @pkgdist.check_define('HAVE_DIRENT_D_TYPE')
+        @pkgdist.print_check("Checking for struct dirent.d_type")
+        def check_HAVE_DIRENT_D_TYPE(self):
+            return self.check_struct_member('struct dirent', 'd_type',
+                    ('dirent.h',))
+
 if not pkgdist.is_py3k:
     extensions.extend([
         OptionalExtension(

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
         'sdist': pkgdist.sdist,
         'build_ext': pkgdist.build_ext,
         'build_py': pkgdist.build_py,
+        'config': pkgdist.config,
         'test': pkgdist.test,
     },
     classifiers=[

--- a/snakeoil/dist/distutils_extensions.py
+++ b/snakeoil/dist/distutils_extensions.py
@@ -415,14 +415,13 @@ class build_ext(dst_build_ext.build_ext):
         return dst_build_ext.build_ext.run(self)
 
     def build_extensions(self):
-        if self.debug:
-            # say it with me kids... distutils sucks!
-            for x in ("compiler_so", "compiler", "compiler_cxx"):
+        # say it with me kids... distutils sucks!
+        for x in ("compiler_so", "compiler", "compiler_cxx"):
+            if self.debug:
                 l = [y for y in getattr(self.compiler, x) if y != '-DNDEBUG']
                 l.append('-Wall')
                 setattr(self.compiler, x, l)
-        if not self.disable_distutils_flag_fixing:
-            for x in ("compiler_so", "compiler", "compiler_cxx"):
+            if not self.disable_distutils_flag_fixing:
                 val = getattr(self.compiler, x)
                 if "-fno-strict-aliasing" not in val:
                     val.append("-fno-strict-aliasing")

--- a/snakeoil/dist/distutils_extensions.py
+++ b/snakeoil/dist/distutils_extensions.py
@@ -28,7 +28,7 @@ from distutils.core import Command, Extension
 from distutils.errors import DistutilsExecError
 from distutils.command import (
     sdist as dst_sdist, build_ext as dst_build_ext, build_py as dst_build_py,
-    build as dst_build, build_scripts as dst_build_scripts)
+    build as dst_build, build_scripts as dst_build_scripts, config as dst_config)
 
 # top level repo/tarball directory
 TOPDIR = os.path.dirname(os.path.abspath(inspect.stack(0)[1][1]))
@@ -409,6 +409,11 @@ class build_ext(dst_build_ext.build_ext):
                 if self.default_header_install_dir not in e.include_dirs:
                     e.include_dirs.append(self.default_header_install_dir)
 
+    def run(self):
+        # ensure that the platform checks were performed
+        self.run_command('config')
+        return dst_build_ext.build_ext.run(self)
+
     def build_extensions(self):
         if self.debug:
             # say it with me kids... distutils sucks!
@@ -712,6 +717,12 @@ class PyTest(Command):
         ret = subprocess.call([sys.executable, '-m', 'pytest'] + self.test_args)
         os.chdir(TOPDIR)
         sys.exit(ret)
+
+
+class config(dst_config.config):
+    """Perform platform checks for extension build"""
+
+    pass
 
 
 # yes these are in snakeoil.compatibility; we can't rely on that module however

--- a/snakeoil/dist/distutils_extensions.py
+++ b/snakeoil/dist/distutils_extensions.py
@@ -719,10 +719,30 @@ class PyTest(Command):
         sys.exit(ret)
 
 
+def print_check(message, if_yes='found', if_no='not found'):
+    """Decorator to print pre/post-check messages"""
+    def sub_decorator(f):
+        def sub_func(*args, **kwargs):
+            sys.stderr.write('-- %s\n' % (message,))
+            result = f(*args, **kwargs)
+            sys.stderr.write('-- %s -- %s\n' % (message,
+                if_yes if result else if_no))
+            return result
+        return sub_func
+    return sub_decorator
+
+
 class config(dst_config.config):
     """Perform platform checks for extension build"""
 
-    pass
+    @print_check('Performing basic C toolchain sanity check', 'works', 'broken')
+    def _sanity_check(self):
+        return self.try_link("int main(int argc, char *argv[]) { return 0; }")
+
+    def run(self):
+        if not self._sanity_check():
+            sys.stderr.write('The C toolchain is unable to compile & link a simple C program!\n')
+            sys.exit(1)
 
 
 # yes these are in snakeoil.compatibility; we can't rely on that module however

--- a/snakeoil/dist/distutils_extensions.py
+++ b/snakeoil/dist/distutils_extensions.py
@@ -766,6 +766,14 @@ class config(dst_config.config):
             if hasattr(getattr(self, k), 'pkgdist_config_decorated'):
                 getattr(self, k)()
 
+    # == methods for custom checks ==
+    def check_struct_member(self, typename, member, headers=None,
+            include_dirs=None, lang="c"):
+        """Check whether type typename (which needs to be struct
+        or union) has the named member."""
+        return self.try_compile('int main() { %s x; (void) x.%s; return 0; }'
+                % (typename, member), headers, include_dirs, lang)
+
 
 # yes these are in snakeoil.compatibility; we can't rely on that module however
 # since snakeoil source is in 2k form, but this module is 2k/3k compatible.

--- a/snakeoil/dist/distutils_extensions.py
+++ b/snakeoil/dist/distutils_extensions.py
@@ -425,6 +425,13 @@ class build_ext(dst_build_ext.build_ext):
                 val = getattr(self.compiler, x)
                 if "-fno-strict-aliasing" not in val:
                     val.append("-fno-strict-aliasing")
+            if getattr(self.distribution, 'check_defines', None):
+                val = getattr(self.compiler, x)
+                for d, result in self.distribution.check_defines.items():
+                    if result:
+                        val.append('-D%s=1' % d)
+                    else:
+                        val.append('-U%s' % d)
         return dst_build_ext.build_ext.build_extensions(self)
 
 
@@ -764,6 +771,9 @@ class config(dst_config.config):
                 continue
             if hasattr(getattr(self, k), 'pkgdist_config_decorated'):
                 getattr(self, k)()
+
+        # store results in Distribution instance
+        self.distribution.check_defines = self.check_defines
 
     # == methods for custom checks ==
     def check_struct_member(self, typename, member, headers=None,

--- a/snakeoil/dist/distutils_extensions.py
+++ b/snakeoil/dist/distutils_extensions.py
@@ -728,6 +728,19 @@ def print_check(message, if_yes='found', if_no='not found'):
             sys.stderr.write('-- %s -- %s\n' % (message,
                 if_yes if result else if_no))
             return result
+        sub_func.pkgdist_config_decorated = True
+        return sub_func
+    return sub_decorator
+
+
+def check_define(define_name):
+    """Method decorator to store check result"""
+    def sub_decorator(f):
+        def sub_func(self, *args, **kwargs):
+            result = f(self, *args, **kwargs)
+            self.check_defines[define_name] = result
+            return result
+        sub_func.pkgdist_config_decorated = True
         return sub_func
     return sub_decorator
 
@@ -743,6 +756,15 @@ class config(dst_config.config):
         if not self._sanity_check():
             sys.stderr.write('The C toolchain is unable to compile & link a simple C program!\n')
             sys.exit(1)
+
+        self.check_defines = {}
+
+        # run all decorated methods
+        for k in dir(self):
+            if k.startswith('_'):
+                continue
+            if hasattr(getattr(self, k), 'pkgdist_config_decorated'):
+                getattr(self, k)()
 
 
 # yes these are in snakeoil.compatibility; we can't rely on that module however

--- a/src/posix.c
+++ b/src/posix.c
@@ -670,7 +670,7 @@ snakeoil_readlines_get_mtime(snakeoil_readlines *self)
 	Py_DECREF(ret);
 	if (is_float)
 		return PyFloat_FromDouble(self->mtime + 1e-9 * self->mtime_nsec);
-#if SIZEOF_TIME_T > SIZEOF_LONG
+#ifdef TIME_T_LONGER_THAN_LONG
 	return PyLong_FromLong((Py_LONG_LONG)self->mtime);
 #else
 	return PyInt_FromLong((long)self->mtime);


### PR DESCRIPTION
Added quite neat platform check framework for `config` command, and quite Pythonic too thanks to decorators.

- [x] `struct stat.st_mtim.tv_nsec` is now used on Linux & Solaris (unavailable on OSX), was disabled before because of missing `-D`,
- [x] `struct dirent.de_type` is no longer forced on Solaris (where it's unavailable),
- [x] the `#if SIZEOF_TIME_T > SIZEOF_LONG` condition was replaced with a single `#ifdef` determined at configure time. Easier to check the condition that guess type sizes.