### PR TITLE
test_cli: Skip test if argparse is already monkey-patched by snakeoil

### DIFF
--- a/snakeoil/test/test_cli.py
+++ b/snakeoil/test/test_cli.py
@@ -2,7 +2,7 @@
 # License: GPL2/BSD 3 clause
 
 import argparse
-from unittest import TestCase
+from unittest import SkipTest, TestCase
 
 
 class TestCli(TestCase):
@@ -11,10 +11,16 @@ class TestCli(TestCase):
         parser = argparse.ArgumentParser()
 
         parser.add_argument('--foo', action='store_true')
-        # add_argument() doesn't support docs kwargs
-        with self.assertRaises(TypeError):
+        # add_argument() shouldn't support docs kwargs
+        # if it does, then likely it is patched already and we can't
+        # test properly
+        try:
             parser.add_argument(
                 '-b', '--blah', action='store_true', docs='Blah blah blah')
+        except TypeError:
+            pass
+        else:
+            raise SkipTest('argparse seems patched already')
 
         # monkeypatch add_argument() from argparse to allow docs kwargs
         from snakeoil import cli


### PR DESCRIPTION
Skip test_cli if argparse has been already monkey-patched rather than
failing. This seems to happen for me when tests are run via 'setup.py
test'.