### PR TITLE
jit_attr: pass the functors docstring through if possible.

### DIFF
--- a/snakeoil/klass.py
+++ b/snakeoil/klass.py
@@ -102,7 +102,9 @@ def native_reflective_hash(attr):
     return __hash__
 
 
-class _native_internal_jit_attr(object):
+def _native_internal_jit_attr(
+    func, attr_name, singleton=None,
+    use_cls_setattr=False, use_singleton=True, doc=None):
 
     """
     object implementing the descriptor protocol for use in Just In Time access to attributes.
@@ -110,6 +112,22 @@ class _native_internal_jit_attr(object):
     Consumers should likely be using the :py:func:`jit_func` line of helper functions
     instead of directly consuming this.
     """
+    doc = getattr(func, '__doc__', None) if doc is None else doc
+    kls = _raw_native_internal_jit_attr
+    if doc is not None:
+       class _native_internal_jit_attr(kls):
+           __doc__ = doc
+           __slots__ = ()
+       kls = _native_internal_jit_attr
+
+    return kls(
+        func, attr_name, singleton=singleton, use_cls_setattr=use_cls_setattr,
+        use_singleton=use_singleton)
+
+
+class _raw_native_internal_jit_attr(object):
+
+    """See _native_internal_jit_attr; this is an implementation detail of that"""
 
     __slots__ = ("storage_attr", "function", "_setter", "singleton", "use_singleton")
 

--- a/src/klass.c
+++ b/src/klass.c
@@ -228,17 +228,19 @@ typedef struct {
 	PyObject *storage_attr;
 	PyObject *function;
 	PyObject *singleton;
+	PyObject *doc;
 	int use_setattr;
 	int use_singleton;
 } snakeoil_InternalJitAttr;
 
 static PyMemberDef snakeoil_InternalJitAttr_members[] = {
 	{"storage_attr", T_OBJECT_EX, offsetof(snakeoil_InternalJitAttr, storage_attr),
-		0, "attribute the value is cached in"},
+		READONLY, "attribute the value is cached in"},
 	{"function", T_OBJECT_EX, offsetof(snakeoil_InternalJitAttr, function),
-		0, "functor to cache values from"},
+		READONLY, "functor to cache values from"},
 	{"singleton", T_OBJECT_EX, offsetof(snakeoil_InternalJitAttr, singleton),
-		0, "singleton value to look for if regeneration is needed, or if unset"},
+		READONLY, "singleton value to look for if regeneration is needed, or if unset"},
+	{"__doc__", T_OBJECT, offsetof(snakeoil_InternalJitAttr,doc), READONLY},
 	{NULL}
 };
 
@@ -248,6 +250,7 @@ snakeoil_InternalJitAttr_clear(snakeoil_InternalJitAttr *self)
 	Py_CLEAR(self->storage_attr);
 	Py_CLEAR(self->function);
 	Py_CLEAR(self->singleton);
+	Py_CLEAR(self->doc);
 	return 0;
 }
 static void
@@ -262,17 +265,18 @@ snakeoil_InternalJitAttr_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
 	snakeoil_InternalJitAttr *self;
 	PyObject *attr = NULL, *func = NULL, *singleton = NULL,
-		*use_setattr_obj = NULL, *use_singleton_obj = NULL;
+		*use_setattr_obj = NULL, *use_singleton_obj = NULL,
+		*doc = NULL;
 
 	int use_setattr = 0;
 	int use_singleton = 1;
 
 	static char *kwlist[] = {"func", "attr_name", "singleton", "use_cls_setattr",
-		"use_singleton", NULL};
+		"use_singleton", "doc", NULL};
 
-	if (!PyArg_ParseTupleAndKeywords(args, kwds, "OS|OOO:__new__",
+	if (!PyArg_ParseTupleAndKeywords(args, kwds, "OS|OOOO:__new__",
 		kwlist,
-		&func, &attr, &singleton, &use_setattr_obj, &use_singleton_obj))
+		&func, &attr, &singleton, &use_setattr_obj, &use_singleton_obj, &doc))
 		return NULL;
 
 	if (use_setattr_obj) {
@@ -285,6 +289,12 @@ snakeoil_InternalJitAttr_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 		if (-1 == (use_singleton = PyObject_IsTrue(use_singleton_obj))) {
 			return NULL;
 		}
+	}
+
+	if (doc == NULL || doc == Py_None) {
+		// Steal the doc from the func now.
+		doc = PyObject_GetAttrString(func, "__doc__");
+        PyErr_Clear();
 	}
 
 	self = (snakeoil_InternalJitAttr *)type->tp_alloc(type, 0);
@@ -300,6 +310,8 @@ snakeoil_InternalJitAttr_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 		self->singleton = singleton;
 		self->use_setattr = use_setattr;
 		self->use_singleton = use_singleton;
+		Py_INCREF(doc);
+		self->doc = doc;
 	}
 	return (PyObject *)self;
 }


### PR DESCRIPTION
Barring that, allow the doc to be overriden; core goal is to avoid just reusing
the docstring of the implementation.  Issue #30.
