### PR TITLE
snakeoil.xml: Prefer lxml.etree whenever available

### DIFF
--- a/snakeoil/xml/__init__.py
+++ b/snakeoil/xml/__init__.py
@@ -2,11 +2,16 @@
 # License: BSD/GPL2
 
 """
-Compatibility code, preferring cElementTree, falling back to ElementTree.
+Compatibility code, preferring lxml, then cElementTree, then falling
+back to ElementTree.
 """
 
 try:
     # pylint: disable=import-error
-    from xml.etree import cElementTree as etree
+    from lxml import etree
 except ImportError:
-    from xml.etree import ElementTree as etree
+    try:
+        # pylint: disable=import-error
+        from xml.etree import cElementTree as etree
+    except ImportError:
+        from xml.etree import ElementTree as etree


### PR DESCRIPTION
lxml is the modern XML library for Python using libxml2. It provides its own ElementTree implementation as `lxml.etree`, and should work nice in place of current code.