### PR TITLE
setuptools doesn't provide install_headers by

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ Installing from git in a virtualenv::
 
 Installing from a tarball or git repo::
 
-    python setup.py install
+    python setup.py install install_headers
 
 Tests
 =====


### PR DESCRIPTION
default unlike pip, add note to README (pkgcore #186)