### PR TITLE
compression: Fix args in external bz2 fallback

### DIFF
--- a/snakeoil/compression/_bzip2.py
+++ b/snakeoil/compression/_bzip2.py
@@ -58,7 +58,7 @@ except process.CommandNotFound:
 
 def compress_data(data, level=9, parallelize=False):
     if parallelize and parallelizable:
-        return _util.compress_data(lbzip2_path, data, level=level,
+        return _util.compress_data(lbzip2_path, data, compresslevel=level,
                                    extra_args=lbzip2_compress_args)
     return _compress_data(data, compresslevel=level)
 
@@ -70,11 +70,11 @@ def decompress_data(data, parallelize=False):
 
 def compress_handle(handle, level=9, parallelize=False):
     if parallelize and parallelizable:
-        return _util.compress_handle(lbzip2_path, handle, level=level,
+        return _util.compress_handle(lbzip2_path, handle, compresslevel=level,
                                      extra_args=lbzip2_compress_args)
     elif native and isinstance(handle, basestring):
         return BZ2File(handle, mode='w', compresslevel=level)
-    return _compress_handle(handle, level=level)
+    return _compress_handle(handle, compresslevel=level)
 
 def decompress_handle(handle, parallelize=False):
     if parallelize and parallelizable:

--- a/snakeoil/compression/_util.py
+++ b/snakeoil/compression/_util.py
@@ -24,8 +24,8 @@ def _drive_process(args, mode, data):
         if p is not None and p.returncode is None:
             p.kill()
 
-def compress_data(binary, data, level=9, extra_args=()):
-    args = [binary, '-%ic' % level]
+def compress_data(binary, data, compresslevel=9, extra_args=()):
+    args = [binary, '-%ic' % compresslevel]
     args.extend(extra_args)
     return _drive_process(args, 'compression', data)
 
@@ -168,8 +168,8 @@ class _process_handle(object):
         self.close()
 
 
-def compress_handle(binary_path, handle, level=9, extra_args=()):
-    args = [binary_path, '-%ic' % level]
+def compress_handle(binary_path, handle, compresslevel=9, extra_args=()):
+    args = [binary_path, '-%ic' % compresslevel]
     args.extend(extra_args)
     return _process_handle(handle, args, False)
 


### PR DESCRIPTION
Fix the external bzip2 fallback (when bz2 module is not available) to
use 'compresslevel' arg (rather than 'level'), consistently with
the argument used by the built-in module. This fixes the calls when
the bz2 module is actually unavailable.