### PR TITLE
chksum: Support SHA3 and BLAKE2*

### DIFF
--- a/src/snakeoil/chksum/__init__.py
+++ b/src/snakeoil/chksum/__init__.py
@@ -124,8 +124,11 @@ def get_chksums(location, *chksums, **kwds):
         parallelize = False
     else:
         parallelize = kwds.get("parallelize", True)
+    can_mmap = True
+    for k in chksums:
+        can_mmap &= handlers[k].can_mmap
     return chksum_loop_over_file(location, [handlers[k].new() for k in chksums],
-                                 parallelize=parallelize)
+                                 parallelize=parallelize, can_mmap=can_mmap)
 
 
 class LazilyHashedPath(object):

--- a/src/snakeoil/chksum/defaults.py
+++ b/src/snakeoil/chksum/defaults.py
@@ -261,6 +261,8 @@ for k, v, str_size in (
         ("sha256", "SHA256", sha256_size),
         ("sha512", "SHA512", sha512_size),
         ("rmd160", "RIPEMD", rmd160_size),
+        ("sha3_256", "SHA3_256", sha3_256_size),
+        ("sha3_512", "SHA3_512", sha3_512_size),
     ):
     if k in chksum_types:
         continue
@@ -269,6 +271,20 @@ for k, v, str_size in (
             "Crypto.Hash.%s.new" % v), str_size)
     except modules.FailedImport:
         pass
+
+# BLAKE2 in pycryptodome needs explicit length parameter
+for k, v, str_size in (
+        ("blake2b", "BLAKE2b", blake2b_size),
+        ("blake2s", "BLAKE2s", blake2s_size),
+    ):
+    if k in chksum_types:
+        continue
+    try:
+        chksum_types[k] = Chksummer(k, partial(modules.load_attribute(
+            "Crypto.Hash.%s.new" % v), digest_bytes=str_size//2), str_size)
+    except modules.FailedImport:
+        pass
+
 # pylint: disable=undefined-loop-variable
 del k, v
 

--- a/src/snakeoil/chksum/defaults.py
+++ b/src/snakeoil/chksum/defaults.py
@@ -33,6 +33,10 @@ rmd160_size = 40
 sha256_size = 64
 sha512_size = 128
 whirlpool_size = 128
+sha3_256_size = 64
+sha3_512_size = 128
+blake2b_size = 128
+blake2s_size = 64
 
 
 def chf_thread(queue, callback):
@@ -231,6 +235,10 @@ for hashlibname, chksumname, size in [
 for hashlibname, chksumname, size in [
         ('ripemd160', 'rmd160', rmd160_size),
         ('whirlpool', 'whirlpool', whirlpool_size),
+        ('sha3_256', 'sha3_256', sha3_256_size),
+        ('sha3_512', 'sha3_512', sha3_512_size),
+        ('blake2b', 'blake2b', blake2b_size),
+        ('blake2s', 'blake2s', blake2s_size),
     ]:
     try:
         hashlib.new(hashlibname)

--- a/src/snakeoil/test/test_chksum_defaults.py
+++ b/src/snakeoil/test/test_chksum_defaults.py
@@ -87,6 +87,10 @@ checksums = {
     "sha256": "68ae37b45e4a4a5df252db33c0cbf79baf5916b5ff6fc15e8159163b6dbe3bae",
     "sha512": "cdc2b749d28cd9c5fca45d3ca6b65661445decd992da93054fd6f4f3e4013ca8b44b0ba159d1cf1f58f9af2b9d267343b9e10f611494c0850fdcebe0379135c6",
     "whirlpool": "3f683be80ee004962cfbd1ddb99437f5f3c9f0fd024e18525b6aa080c9fd9d060415d9a8383462b9ddc065f176f5cb257728c33d8e12bbdd47216320350943aa",
+    "sha3_256": "33e910cd302a2a210ccd9bc5331d61c164aa228a23af2ae97edc9eb60ddb01f9",
+    "sha3_512": "820e3526c76ca2c41582439c50b395aef7560ae57c5d6273fe7dbaa01f4f1f121ddbb147cf42fc23e0a2823bf0bb4c47027cd35620141126d374c6782a512f95",
+    "blake2b": "9f9bbd37d28994c871fffbc21358358e79c85c80fad70a0c0ce5998ff9ff04001f4984ec46e596bd4c482adc701cca44f70318c389dc6014c1bb5818d6991c7f",
+    "blake2s": "805b836cb59b5144b2a738422b342a90fbdc0dd8e75321eb3022766ff333a7b1",
 }
 checksums.update((k, (long(v, 16), v)) for k, v in checksums.iteritems())
 checksums["size"] = (long(len(data) * multi), str(long(len(data) * multi)))


### PR DESCRIPTION
Includes:
* support for SHA3 and BLAKE2 from python3.6 hashlib + pycryptodome
* fix using pycrypto(dome) since it doesn't support passing mmap objects
* fix skipping crypto tests and make tests verbose