### PR TITLE
fileutils: Do not raise StopIteration in generators, for py37

### DIFF
--- a/src/snakeoil/_fileutils.py
+++ b/src/snakeoil/_fileutils.py
@@ -55,7 +55,6 @@ class readlines_iter(object):
         for _ in ():
             yield None
         source.close()
-        raise StopIteration()
 
     def close(self):
         if hasattr(self.source, 'close'):


### PR DESCRIPTION
Remove explicit 'raise StopIteration' from generator code in fileutils,
as it is entirely unnecessary, and explicitly forbidden in Python 3.7.
