### PR TITLE
test_obj: Ignore __class_getitem__

### DIFF
--- a/tests/module/test_obj.py
+++ b/tests/module/test_obj.py
@@ -23,7 +23,8 @@ class TestDelayedInstantiation:
         def assertKls(cls, ignores=(),
                       default_ignores=("__new__", "__init__", "__init_subclass__",
                                        "__getattribute__", "__class__",
-                                       "__getnewargs__", "__doc__")):
+                                       "__getnewargs__", "__doc__",
+                                       "__class_getitem__")):
             required = set(x for x in dir(cls)
                            if x.startswith("__") and x.endswith("__"))
             missing = required.difference(obj.kls_descriptors)


### PR DESCRIPTION
Ignore `__class_getitem__` special that was added to some stdlib objects
in Python 3.9.  It is used as part of type declarations.