### PR TITLE
PyPy support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ['3.8', '3.9', 'pypy-3.8-7.3.6rc2']
+        python-version: ['3.8', '3.9', 'pypy-3.8']
         experimental: [false]
         include:
           - os: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ['3.8', '3.9']
+        python-version: ['3.8', '3.9', 'pypy-3.8-7.3.6rc2']
         experimental: [false]
         include:
           - os: ubuntu-latest

--- a/src/snakeoil/mappings.py
+++ b/src/snakeoil/mappings.py
@@ -630,6 +630,9 @@ class defaultdictkey(defaultdict):
     Specifically, if instance[missing_key] is accessed, the `__missing__` method automatically
     store self[missing_key] = self.default_factory(key).
     """
+
+    __slots__ = ()
+
     def __init__(self, default_factory):
         # we have our own init to explicitly force via prototype
         # that a default_factory is required

--- a/src/snakeoil/obj.py
+++ b/src/snakeoil/obj.py
@@ -89,10 +89,12 @@ from . import klass
 base_kls_descriptors = [
     '__delattr__', '__hash__', '__reduce__',
     '__reduce_ex__', '__repr__', '__setattr__', '__str__',
-    '__sizeof__', '__format__', '__subclasshook__',  # >=py2.6
+    '__format__', '__subclasshook__',  # >=py2.6
     '__le__', '__lt__', '__ge__', '__gt__', '__eq__', '__ne__',  # py3
     '__dir__',  # >=py3.3
 ]
+if hasattr(object, '__sizeof__'):
+    base_kls_descriptors.append('__sizeof__')
 base_kls_descriptors = frozenset(base_kls_descriptors)
 
 
@@ -189,7 +191,7 @@ kls_descriptors = frozenset([
     '__coerce__', '__trunc__', '__radd__', '__floor__', '__ceil__',
     '__round__',
     # remaining...
-    '__call__',
+    '__call__', '__sizeof__',
 ])
 
 

--- a/src/snakeoil/test/slot_shadowing.py
+++ b/src/snakeoil/test/slot_shadowing.py
@@ -42,7 +42,7 @@ class SlotShadowing(mixins.TargetedNamespaceWalker, mixins.SubclassWalker):
 
             if isinstance(slots, str):
                 slots = (slots,)
-            elif isinstance(slots, dict):
+            elif isinstance(slots, (dict, list)):
                 slots = tuple(slots)
 
             raw_slottings[slots] = parent

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -1,4 +1,5 @@
 import pytest
+import gc
 from snakeoil.caching import WeakInstMeta
 
 
@@ -40,6 +41,7 @@ class TestWeakInstMeta:
         assert o is kls()
         assert kls.counter == 1
         del o
+        gc.collect()
         kls()
         assert kls.counter == 2
 
@@ -49,6 +51,7 @@ class TestWeakInstMeta:
             o = weak_inst(disable_inst_caching=True)
             assert weak_inst.counter is x
         del o
+        gc.collect()
         o = weak_inst()
         assert o is not weak_inst(disable_inst_caching=True)
 
@@ -157,5 +160,6 @@ class TestWeakInstMeta:
         assert weak_inst.counter == 1
         _myid = id(o)
         del o
+        gc.collect()
         o = weak_inst(unique)
         assert weak_inst.counter == 2

--- a/tests/test_contexts.py
+++ b/tests/test_contexts.py
@@ -84,7 +84,7 @@ class TestSplitExec:
         # make sure unpickleables don't cause issues
         with SplitExec() as c:
             func = lambda x: x
-            import sys
+            from sys import implementation
             a = 4
         assert c.locals == {'a': 4}
 

--- a/tests/test_fileutils.py
+++ b/tests/test_fileutils.py
@@ -1,4 +1,5 @@
 import errno
+import gc
 import mmap
 import os
 import time
@@ -92,6 +93,7 @@ class TestAtomicWriteFile(TempDir):
         af = self.kls(fp)
         af.write("dar")
         del af
+        gc.collect()
         assert fileutils.readfile_ascii(fp) == "me"
         assert len(os.listdir(self.dir)) == 1
 


### PR DESCRIPTION
As a follow-up to #52 and discussion in #58, since the first 3.8-compatible PyPy release candidate just appeared, enable testing using the newest version and fix testing incompatibilities.

Not sure if it is possible to use RCs only while the production version is unavailable. It should be enough to remove the `-7.3.6rc2` part when the real release comes, though.