### PR TITLE
distutils_extensions: don't import setuptools._distutils directly

### DIFF
--- a/src/snakeoil/dist/distutils_extensions.py
+++ b/src/snakeoil/dist/distutils_extensions.py
@@ -22,12 +22,12 @@ from datetime import datetime
 from multiprocessing import cpu_count
 
 from setuptools import find_packages
+from setuptools.command import build_py as dst_build_py
 from setuptools.command import install as dst_install
 from setuptools.dist import Distribution
 from distutils import log
 from distutils.command import build as dst_build
 from distutils.command import build_ext as dst_build_ext
-from distutils.command import build_py as dst_build_py
 from distutils.command import build_scripts as dst_build_scripts
 from distutils.command import config as dst_config
 from distutils.command import sdist as dst_sdist

--- a/src/snakeoil/dist/distutils_extensions.py
+++ b/src/snakeoil/dist/distutils_extensions.py
@@ -22,17 +22,17 @@ from datetime import datetime
 from multiprocessing import cpu_count
 
 from setuptools import find_packages
-from setuptools._distutils import log
-from setuptools._distutils.command import build as dst_build
-from setuptools._distutils.command import build_ext as dst_build_ext
-from setuptools._distutils.command import build_py as dst_build_py
-from setuptools._distutils.command import build_scripts as dst_build_scripts
-from setuptools._distutils.command import config as dst_config
-from setuptools._distutils.command import sdist as dst_sdist
-from setuptools._distutils.core import Command, Extension
-from setuptools._distutils.errors import DistutilsError, DistutilsExecError
 from setuptools.command import install as dst_install
 from setuptools.dist import Distribution
+from distutils import log
+from distutils.command import build as dst_build
+from distutils.command import build_ext as dst_build_ext
+from distutils.command import build_py as dst_build_py
+from distutils.command import build_scripts as dst_build_scripts
+from distutils.command import config as dst_config
+from distutils.command import sdist as dst_sdist
+from distutils.core import Command, Extension
+from distutils.errors import DistutilsError, DistutilsExecError
 
 from ..contexts import syspath
 from ..version import get_git_version


### PR DESCRIPTION
For some reason, this causes an ImportError when
DISTUTILS_USE_SETUPTOOLS=local.

setuptools already does some hackery to make setuptools._distutils override
the distutils shipped in the standard libarary. Let's just rely on that.

Bug: https://bugs.gentoo.org/822537