### PR TITLE
distutils_extensions: fix import w/ newer setuptools(?)

### DIFF
--- a/src/snakeoil/dist/distutils_extensions.py
+++ b/src/snakeoil/dist/distutils_extensions.py
@@ -50,6 +50,10 @@ if REPODIR is None:
         if os.path.basename(_filename) == 'setup.py':
             REPODIR = os.path.dirname(os.path.abspath(_filename))
             break
+        elif os.path.basename(_filename) == 'distutils_extensions.py':
+            # https://github.com/pkgcore/snakeoil/issues/69
+            REPODIR = os.path.dirname(os.path.abspath(_filename + '../..'))
+            break
     else:
         raise ImportError('this module is only meant to be imported in setup.py scripts')
 


### PR DESCRIPTION
I'm not going to ask too many questions as we should
really ditch this anyway.

Closes: https://github.com/pkgcore/snakeoil/issues/69
Signed-off-by: Sam James <sam@gentoo.org>