### PR TITLE
compression: prefer gtar over tar if available

### DIFF
--- a/src/snakeoil/compression/__init__.py
+++ b/src/snakeoil/compression/__init__.py
@@ -145,7 +145,7 @@ class _CompressedStdin:
 class _Tar(_Archive, ArComp):
 
     exts = frozenset(['.tar'])
-    binary = ('tar',)
+    binary = ('gtar', 'tar',)
     compress_binary = None
     default_unpack_cmd = '{binary} xf "{path}"'
 
@@ -156,6 +156,7 @@ class _Tar(_Archive, ArComp):
             for b in self.compress_binary:
                 try:
                     process.find_binary(b[0])
+                    # FIXME: This is a gnuism, needs gnu tar.
                     cmd += f' --use-compress-program="{" ".join(b)}"'
                     break
                 except process.CommandNotFound:


### PR DESCRIPTION
Prefer 'gtar' over 'tar' if available, as we need GNU tar for --use-compress-program.

With libarchive's tar, we get an 'unrecognized archive' error.

Signed-off-by: Sam James <sam@gentoo.org>