### PR TITLE
Include LICENSE in sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ Documentation = "https://pkgcore.github.io/snakeoil/"
 Source = "https://github.com/pkgcore/snakeoil"
 
 [tool.flit.sdist]
-include = ["doc", "tox.ini", "tests", "Makefile", "NEWS.rst"]
+include = ["doc", "tox.ini", "tests", "LICENSE", "Makefile", "NEWS.rst"]
 exclude = [".github/", ".gitignore", "doc/api/"]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
I noticed there was no license file in the pypi source tarball while building from source. I hope this is okay to do so.

If it is desired, I can also bump the year in LICENSE in a separate commit - maybe to even 2023!