### PR TITLE
arghparse: fix compatibility with Python 3.12.8

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -2,6 +2,11 @@
 Release Notes
 =============
 
+snakeoil 0.10.10 (2024-12-04)
+----------------------------
+
+- arghparse: fix compatibility with Python 3.12.8 (Michał Górny)
+
 snakeoil 0.10.9 (2024-10-02)
 ----------------------------
 

--- a/src/snakeoil/__init__.py
+++ b/src/snakeoil/__init__.py
@@ -11,4 +11,4 @@ This library is a bit of a grabbag of the following:
 """
 
 __title__ = "snakeoil"
-__version__ = "0.10.9"
+__version__ = "0.10.10"

--- a/src/snakeoil/cli/arghparse.py
+++ b/src/snakeoil/cli/arghparse.py
@@ -1247,7 +1247,15 @@ class ArgumentParser(OptionalsParser, CsvActionsParser):
                 namespace, args = functor(parser, namespace, args)
 
             # parse the arguments and exit if there are any errors
-            namespace, args = self._parse_known_args(args, namespace)
+            # Python 3.12.8 introduced obligatory intermixed arg.  The same
+            # commit adds _parse_known_args2 function, so use that to determine
+            # if we need to pass that.
+            if hasattr(self, "_parse_known_args2"):
+                namespace, args = self._parse_known_args(
+                    args, namespace, intermixed=False
+                )
+            else:
+                namespace, args = self._parse_known_args(args, namespace)
             if hasattr(namespace, _UNRECOGNIZED_ARGS_ATTR):
                 args.extend(getattr(namespace, _UNRECOGNIZED_ARGS_ATTR))
                 delattr(namespace, _UNRECOGNIZED_ARGS_ATTR)


### PR DESCRIPTION
Closes: https://github.com/pkgcore/snakeoil/issues/103