### PR TITLE
Loosen slot_shadowing checks into a warning

### DIFF
--- a/src/snakeoil/test/slot_shadowing.py
+++ b/src/snakeoil/test/slot_shadowing.py
@@ -1,7 +1,3 @@
-import warnings
-
-import pytest
-
 from . import mixins
 
 
@@ -86,9 +82,3 @@ class SlotShadowing(mixins.TargetedNamespaceWalker, mixins.SubclassWalker):
                 self.report_issue(
                     f"cls {kls!r}; slot {slot!r} was already defined at {slotting[slot]!r}"
                 )
-
-    def report_issue(self, message):
-        if self.strict:
-            pytest.fail(message)
-        else:
-            warnings.warn(f"slot_shadowing detected: {message}")

--- a/src/snakeoil/test/slot_shadowing.py
+++ b/src/snakeoil/test/slot_shadowing.py
@@ -1,3 +1,5 @@
+import warnings
+
 import pytest
 
 from . import mixins
@@ -7,6 +9,7 @@ class SlotShadowing(mixins.TargetedNamespaceWalker, mixins.SubclassWalker):
     target_namespace = "snakeoil"
     err_if_slots_is_str = True
     err_if_slots_is_mutable = True
+    strict = False
 
     def recurse_parents(self, kls, seen=None):
         if not seen:
@@ -54,7 +57,7 @@ class SlotShadowing(mixins.TargetedNamespaceWalker, mixins.SubclassWalker):
 
         if isinstance(slots, str):
             if self.err_if_slots_is_str:
-                pytest.fail(
+                self.report_issue(
                     f"cls {kls!r}; slots is {slots!r} (should be a tuple or list)"
                 )
             slots = (slots,)
@@ -64,20 +67,28 @@ class SlotShadowing(mixins.TargetedNamespaceWalker, mixins.SubclassWalker):
 
         if not isinstance(slots, tuple):
             if self.err_if_slots_is_mutable:
-                pytest.fail(f"cls {kls!r}; slots is {slots!r}- - should be a tuple")
+                self.report_issue(
+                    f"cls {kls!r}; slots is {slots!r}- - should be a tuple"
+                )
             slots = tuple(slots)
 
         if slots is None or (slots and slots in raw_slottings):
             # we do a bool on slots to ignore (); that's completely valid
             # this means that the child either didn't define __slots__, or
             # daftly copied the parents... thus defeating the purpose.
-            pytest.fail(
+            self.report_issue(
                 f"cls {kls!r}; slots is {slots!r}, seemingly inherited from "
                 f"{raw_slottings[slots]!r}; the derivative class should be __slots__ = ()"
             )
 
         for slot in slots:
             if slot in slotting:
-                pytest.fail(
+                self.report_issue(
                     f"cls {kls!r}; slot {slot!r} was already defined at {slotting[slot]!r}"
                 )
+
+    def report_issue(self, message):
+        if self.strict:
+            pytest.fail(message)
+        else:
+            warnings.warn(f"slot_shadowing detected: {message}")

--- a/tests/test_slot_shadowing.py
+++ b/tests/test_slot_shadowing.py
@@ -2,4 +2,4 @@ from snakeoil.test.slot_shadowing import SlotShadowing
 
 
 class Test_slot_shadowing(SlotShadowing):
-    pass
+    strict = True


### PR DESCRIPTION
Slot shadowing- in py2k- lead to some fairly fucked up things where one layer of class could see something different than higher up.  Plus it wasted memory and is technically a 'bug' in layout, but mostly the former is why the check exists.

Py3k fixed that issue, but the check *is* desirable- it just shouldn't be a full assert failure unless the codebase is self contained (snakeoil) and can assert that it internally is correct.  Thus default this reusable class to non strict, which in turn will make pkgcore no longer fail for slot fixes within snakeoil..

Additionally, tweak it so it collects all issues rather than bailing after the first one.

This slot_shadowing mixin code is nasty af due to it's age- decent chance it's older than a few gentoo devs.  It absolutely needs to be rewritten, something I'll look into later.

Later, I'll rewrite this logic (via klass.get_slots_of) to be configurable for what level of assertion:
* total: any shadowing, fail (previous behavior)
* partial: scan the class chain to know where the original slot came from.  If it's not from within the target (pkgcore), warn.  IE, if pkgcore kls2 inherits kl1, and kls2 shadows something kls1 did- flag that.  If kls1 inherits from snakeoil and the issue is that layer, warn for that.
* advisory: just warn.

Total and advisory exist via this PR's default `strict=False`, that'll get adjusted whenever I get around to writing the partial implementation.